### PR TITLE
fix: harden DNS CLI lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,10 +18,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-trait"
@@ -66,6 +96,17 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -132,6 +173,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,7 +193,10 @@ dependencies = [
 name = "dns-check-rust"
 version = "0.2.0"
 dependencies = [
+ "assert_cmd",
+ "hickory-proto",
  "hickory-resolver",
+ "predicates",
  "tokio",
 ]
 
@@ -173,6 +223,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -558,9 +617,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miniz_oxide"
@@ -597,6 +656,21 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -691,6 +765,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +877,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "resolv-conf"
@@ -930,6 +1063,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1205,15 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ edition = "2021"
 [dependencies]
 hickory-resolver = "0.25.2"
 tokio = { version = "1.38.2", features = ["macros", "rt-multi-thread"] }
+
+[dev-dependencies]
+assert_cmd = "2.0.16"
+hickory-proto = "0.25.2"
+predicates = "3.1.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,144 @@
-use hickory_resolver::config::*;
+use hickory_resolver::config::{NameServerConfig, NameServerConfigGroup, ResolverConfig};
 use hickory_resolver::name_server::TokioConnectionProvider;
-use hickory_resolver::proto::rr::RecordType;
+use hickory_resolver::proto::rr::{domain::Name, RecordType};
+use hickory_resolver::proto::xfer::Protocol;
 use hickory_resolver::TokioResolver;
 use std::env;
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::path::Path;
+use std::process::ExitCode;
 use tokio::task::JoinSet;
+
+const TEST_RESOLVERS_ENV: &str = "DNS_CHECK_TEST_RESOLVERS";
 
 #[derive(Clone)]
 struct Server {
-    ip: String,
+    socket_addr: SocketAddr,
     location: String,
     provider: String,
 }
 
-#[tokio::main]
-async fn main() {
-    let args: Vec<String> = env::args().collect();
+#[derive(Debug)]
+enum CliError {
+    Usage(String),
+    Validation(String),
+    AllLookupsFailed,
+}
 
-    if args.len() < 3 {
-        println!("Usage: dnscheck <domain> <record_type>");
-        return;
+impl CliError {
+    fn exit_code(&self) -> ExitCode {
+        match self {
+            Self::Usage(_) | Self::Validation(_) => ExitCode::from(2),
+            Self::AllLookupsFailed => ExitCode::from(1),
+        }
     }
+}
 
-    let domain = &args[1];
-    let record_type = match parse_record_type(&args[2]) {
-        Ok(record_type) => record_type,
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Usage(message) | Self::Validation(message) => write!(f, "{message}"),
+            Self::AllLookupsFailed => write!(f, "All DNS lookups failed."),
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run(env::args().collect()).await {
+        Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
             eprintln!("{err}");
-            return;
+            err.exit_code()
         }
-    };
+    }
+}
 
-    let servers = vec![
+async fn run(args: Vec<String>) -> Result<(), CliError> {
+    let binary_name = args
+        .first()
+        .map(|arg| binary_name(arg))
+        .unwrap_or_else(|| "dns-check-rust".to_string());
+
+    if args.len() < 3 {
+        return Err(CliError::Usage(format!(
+            "Usage: {binary_name} <domain> <record_type>"
+        )));
+    }
+
+    let record_type = parse_record_type(&args[2]).map_err(CliError::Validation)?;
+    let query_name = normalize_query_name(&args[1], record_type);
+    let servers = load_servers().map_err(CliError::Validation)?;
+
+    check_dns_propagation(&query_name, record_type, &servers).await
+}
+
+fn binary_name(arg0: &str) -> String {
+    Path::new(arg0)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("dns-check-rust")
+        .to_string()
+}
+
+fn load_servers() -> Result<Vec<Server>, String> {
+    match env::var(TEST_RESOLVERS_ENV) {
+        Ok(raw) => parse_test_servers(&raw),
+        Err(env::VarError::NotPresent) => Ok(default_servers()),
+        Err(err) => Err(format!("Failed to read {TEST_RESOLVERS_ENV}: {err}")),
+    }
+}
+
+fn parse_test_servers(raw: &str) -> Result<Vec<Server>, String> {
+    let servers = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| {
+            entry
+                .parse::<SocketAddr>()
+                .map(|socket_addr| Server {
+                    socket_addr,
+                    location: "Local test".to_string(),
+                    provider: "Injected resolver".to_string(),
+                })
+                .map_err(|_| format!("Invalid {TEST_RESOLVERS_ENV} entry: {entry}"))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if servers.is_empty() {
+        return Err(format!(
+            "{TEST_RESOLVERS_ENV} must contain at least one ip:port entry"
+        ));
+    }
+
+    Ok(servers)
+}
+
+fn default_servers() -> Vec<Server> {
+    vec![
         Server {
-            ip: "8.8.8.8".to_string(),
+            socket_addr: "8.8.8.8:53".parse().unwrap(),
             location: "Mountain View, California".to_string(),
             provider: "Google LLC".to_string(),
         },
         Server {
-            ip: "1.1.1.1".to_string(),
+            socket_addr: "1.1.1.1:53".parse().unwrap(),
             location: "San Francisco, California".to_string(),
             provider: "Cloudflare, Inc".to_string(),
         },
-        // ... Add other servers as needed
-    ];
+    ]
+}
 
-    check_dns_propagation(domain, record_type, &servers).await;
+fn normalize_query_name(query_name: &str, record_type: RecordType) -> String {
+    if record_type == RecordType::PTR {
+        if let Ok(ip) = query_name.parse::<IpAddr>() {
+            return Name::from(ip).to_string();
+        }
+    }
+
+    query_name.to_string()
 }
 
 fn parse_record_type(record_type: &str) -> Result<RecordType, String> {
@@ -59,49 +153,72 @@ fn parse_record_type(record_type: &str) -> Result<RecordType, String> {
         "SOA" => Ok(RecordType::SOA),
         "PTR" => Ok(RecordType::PTR),
         "CAA" => Ok(RecordType::CAA),
-        "ANY" => Ok(RecordType::ANY),
         _ => Err(format!("Unsupported record type: {record_type}")),
     }
 }
 
-async fn check_dns_propagation(domain: &str, record_type: RecordType, servers: &[Server]) {
+async fn check_dns_propagation(
+    query_name: &str,
+    record_type: RecordType,
+    servers: &[Server],
+) -> Result<(), CliError> {
     let mut tasks = JoinSet::new();
+    let mut success_count = 0;
 
     for server in servers.iter().cloned() {
-        let domain = domain.to_string();
-        tasks.spawn(async move { query_server(&domain, record_type, server).await });
+        let query_name = query_name.to_string();
+        tasks.spawn(async move { query_server(&query_name, record_type, server).await });
     }
 
     while let Some(result) = tasks.join_next().await {
         match result {
-            Ok(message) => println!("{message}"),
+            Ok(Ok(message)) => {
+                println!("{message}");
+                success_count += 1;
+            }
+            Ok(Err(err)) => eprintln!("{err}"),
             Err(err) => eprintln!("Task failed: {err}"),
         }
     }
+
+    if success_count == 0 {
+        return Err(CliError::AllLookupsFailed);
+    }
+
+    Ok(())
 }
 
-async fn query_server(domain: &str, record_type: RecordType, server: Server) -> String {
-    let resolver_config = ResolverConfig::from_parts(
-        None,
-        vec![],
-        NameServerConfigGroup::from_ips_clear(&[server.ip.parse().unwrap()], 53, true),
-    );
-    let resolver =
-        TokioResolver::builder_with_config(resolver_config, TokioConnectionProvider::default())
-            .build();
+async fn query_server(
+    query_name: &str,
+    record_type: RecordType,
+    server: Server,
+) -> Result<String, String> {
+    let resolver = TokioResolver::builder_with_config(
+        resolver_config_for_server(server.socket_addr),
+        TokioConnectionProvider::default(),
+    )
+    .build();
 
-    match resolver.lookup(domain, record_type).await {
+    match resolver.lookup(query_name, record_type).await {
         Ok(response) => {
             let answer_str = response
                 .iter()
                 .map(|record| record.to_string())
                 .collect::<Vec<_>>()
                 .join("\n - ");
-            format!(
+
+            Ok(format!(
                 "Server {} ({}, {}) reports:\n - {}",
-                server.ip, server.provider, server.location, answer_str
-            )
+                server.socket_addr, server.provider, server.location, answer_str
+            ))
         }
-        Err(err) => format!("Error querying {}: {:?}", server.ip, err),
+        Err(err) => Err(format!("Error querying {}: {:?}", server.socket_addr, err)),
     }
+}
+
+fn resolver_config_for_server(socket_addr: SocketAddr) -> ResolverConfig {
+    let mut name_servers = NameServerConfigGroup::with_capacity(2);
+    name_servers.push(NameServerConfig::new(socket_addr, Protocol::Udp));
+    name_servers.push(NameServerConfig::new(socket_addr, Protocol::Tcp));
+    ResolverConfig::from_parts(None, vec![], name_servers)
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,294 @@
+use assert_cmd::prelude::*;
+use hickory_proto::op::{Message, MessageType, ResponseCode};
+use hickory_proto::rr::domain::Name;
+use hickory_proto::rr::rdata::PTR;
+use hickory_proto::rr::{RData, Record, RecordType};
+use predicates::prelude::*;
+use std::io::{Read, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, UdpSocket};
+use std::process::Command;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const TEST_RESOLVERS_ENV: &str = "DNS_CHECK_TEST_RESOLVERS";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ObservedQuery {
+    name: String,
+    record_type: RecordType,
+}
+
+#[derive(Clone)]
+enum MockResponse {
+    Address(Ipv4Addr),
+    NxDomain,
+    Ptr(&'static str),
+}
+
+struct MockResolver {
+    socket_addr: SocketAddr,
+    queries: Arc<Mutex<Vec<ObservedQuery>>>,
+    shutdown: Arc<AtomicBool>,
+    udp_thread: Option<JoinHandle<()>>,
+    tcp_thread: Option<JoinHandle<()>>,
+}
+
+impl MockResolver {
+    fn spawn(response: MockResponse) -> Self {
+        let tcp_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let socket_addr = tcp_listener.local_addr().unwrap();
+        let udp_socket = UdpSocket::bind(socket_addr).unwrap();
+        let queries = Arc::new(Mutex::new(Vec::new()));
+        let shutdown = Arc::new(AtomicBool::new(false));
+
+        udp_socket
+            .set_read_timeout(Some(Duration::from_millis(100)))
+            .unwrap();
+        tcp_listener.set_nonblocking(true).unwrap();
+
+        let udp_thread = Some(spawn_udp_server(
+            udp_socket,
+            response.clone(),
+            Arc::clone(&queries),
+            Arc::clone(&shutdown),
+        ));
+        let tcp_thread = Some(spawn_tcp_server(
+            tcp_listener,
+            response,
+            Arc::clone(&queries),
+            Arc::clone(&shutdown),
+        ));
+
+        Self {
+            socket_addr,
+            queries,
+            shutdown,
+            udp_thread,
+            tcp_thread,
+        }
+    }
+
+    fn socket_addr(&self) -> SocketAddr {
+        self.socket_addr
+    }
+
+    fn queries(&self) -> Vec<ObservedQuery> {
+        self.queries.lock().unwrap().clone()
+    }
+}
+
+impl Drop for MockResolver {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+
+        if let Some(handle) = self.udp_thread.take() {
+            handle.join().unwrap();
+        }
+
+        if let Some(handle) = self.tcp_thread.take() {
+            handle.join().unwrap();
+        }
+    }
+}
+
+#[test]
+fn ptr_lookup_normalizes_ip_inputs() {
+    let resolver = MockResolver::spawn(MockResponse::Ptr("dns.google."));
+
+    Command::cargo_bin("dns-check-rust")
+        .unwrap()
+        .env(TEST_RESOLVERS_ENV, resolver.socket_addr().to_string())
+        .args(["8.8.8.8", "PTR"])
+        .assert()
+        .success()
+        .stderr(predicate::str::is_empty())
+        .stdout(predicate::str::contains("dns.google"));
+
+    let queries = resolver.queries();
+    assert!(queries.iter().any(|query| {
+        query.record_type == RecordType::PTR && query.name == "8.8.8.8.in-addr.arpa."
+    }));
+    assert!(!queries.iter().any(|query| query.name == "8.8.8.8."));
+}
+
+#[test]
+fn missing_args_exit_with_usage_error() {
+    Command::cargo_bin("dns-check-rust")
+        .unwrap()
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains(
+            "Usage: dns-check-rust <domain> <record_type>",
+        ));
+}
+
+#[test]
+fn all_failed_lookups_exit_non_zero() {
+    let resolver_a = MockResolver::spawn(MockResponse::NxDomain);
+    let resolver_b = MockResolver::spawn(MockResponse::NxDomain);
+
+    Command::cargo_bin("dns-check-rust")
+        .unwrap()
+        .env(
+            TEST_RESOLVERS_ENV,
+            format!("{},{}", resolver_a.socket_addr(), resolver_b.socket_addr()),
+        )
+        .args(["missing.example", "A"])
+        .assert()
+        .failure()
+        .code(1)
+        .stdout(predicate::str::is_empty())
+        .stderr(
+            predicate::str::contains(format!("Error querying {}", resolver_a.socket_addr()))
+                .and(predicate::str::contains(format!(
+                    "Error querying {}",
+                    resolver_b.socket_addr()
+                )))
+                .and(predicate::str::contains("NXDomain"))
+                .and(predicate::str::contains("All DNS lookups failed.")),
+        );
+}
+
+#[test]
+fn any_queries_are_rejected_before_lookup() {
+    let resolver = MockResolver::spawn(MockResponse::Address(Ipv4Addr::new(127, 0, 0, 1)));
+
+    Command::cargo_bin("dns-check-rust")
+        .unwrap()
+        .env(TEST_RESOLVERS_ENV, resolver.socket_addr().to_string())
+        .args(["example.com", "ANY"])
+        .assert()
+        .failure()
+        .code(2)
+        .stdout(predicate::str::is_empty())
+        .stderr(predicate::str::contains("Unsupported record type: ANY"));
+
+    assert!(resolver.queries().is_empty());
+}
+
+fn spawn_udp_server(
+    socket: UdpSocket,
+    response: MockResponse,
+    queries: Arc<Mutex<Vec<ObservedQuery>>>,
+    shutdown: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let mut buffer = [0_u8; 512];
+
+        while !shutdown.load(Ordering::Relaxed) {
+            match socket.recv_from(&mut buffer) {
+                Ok((len, peer_addr)) => {
+                    if len == 0 {
+                        continue;
+                    }
+
+                    let request = Message::from_vec(&buffer[..len]).unwrap();
+                    record_query(&queries, &request);
+                    let response_bytes = build_response(&request, &response);
+                    socket.send_to(&response_bytes, peer_addr).unwrap();
+                }
+                Err(err)
+                    if err.kind() == std::io::ErrorKind::WouldBlock
+                        || err.kind() == std::io::ErrorKind::TimedOut =>
+                {
+                    continue;
+                }
+                Err(err) => panic!("UDP server error: {err}"),
+            }
+        }
+    })
+}
+
+fn spawn_tcp_server(
+    listener: TcpListener,
+    response: MockResponse,
+    queries: Arc<Mutex<Vec<ObservedQuery>>>,
+    shutdown: Arc<AtomicBool>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        while !shutdown.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    stream
+                        .set_read_timeout(Some(Duration::from_millis(100)))
+                        .unwrap();
+
+                    let mut len_bytes = [0_u8; 2];
+                    if let Err(err) = stream.read_exact(&mut len_bytes) {
+                        if err.kind() == std::io::ErrorKind::TimedOut {
+                            continue;
+                        }
+                        panic!("TCP server read failed: {err}");
+                    }
+
+                    let length = u16::from_be_bytes(len_bytes) as usize;
+                    let mut request_bytes = vec![0_u8; length];
+                    stream.read_exact(&mut request_bytes).unwrap();
+
+                    let request = Message::from_vec(&request_bytes).unwrap();
+                    record_query(&queries, &request);
+
+                    let response_bytes = build_response(&request, &response);
+                    stream
+                        .write_all(&(response_bytes.len() as u16).to_be_bytes())
+                        .unwrap();
+                    stream.write_all(&response_bytes).unwrap();
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(err) => panic!("TCP accept failed: {err}"),
+            }
+        }
+    })
+}
+
+fn record_query(queries: &Arc<Mutex<Vec<ObservedQuery>>>, request: &Message) {
+    let query = request.queries().first().unwrap();
+    queries.lock().unwrap().push(ObservedQuery {
+        name: query.name().to_ascii(),
+        record_type: query.query_type(),
+    });
+}
+
+fn build_response(request: &Message, response: &MockResponse) -> Vec<u8> {
+    let query = request.queries().first().unwrap().clone();
+    let mut message = Message::new();
+    message
+        .set_id(request.id())
+        .set_message_type(MessageType::Response)
+        .set_op_code(request.op_code())
+        .set_authoritative(true)
+        .set_recursion_desired(request.recursion_desired())
+        .set_recursion_available(true)
+        .add_query(query.clone());
+
+    match response {
+        MockResponse::Address(ip) => {
+            message.set_response_code(ResponseCode::NoError);
+            message.add_answer(Record::from_rdata(
+                query.name().clone(),
+                60,
+                RData::A((*ip).into()),
+            ));
+        }
+        MockResponse::NxDomain => {
+            message.set_response_code(ResponseCode::NXDomain);
+        }
+        MockResponse::Ptr(target) => {
+            message.set_response_code(ResponseCode::NoError);
+            message.add_answer(Record::from_rdata(
+                query.name().clone(),
+                60,
+                RData::PTR(PTR(Name::from_str(target).unwrap())),
+            ));
+        }
+    }
+
+    message.to_vec().unwrap()
+}


### PR DESCRIPTION
## Summary
- normalize PTR IP inputs into reverse-DNS names before lookup
- return non-zero exit codes for validation errors and all-resolver failures
- reject ANY queries and add deterministic CLI integration tests for the corrected behavior

## Testing
- cargo test