### PR TITLE
chore: update Rust toolchain to 1.94.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dns-check-rust"
 version = "0.2.0"
 edition = "2021"
+rust-version = "1.94.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.94.1"
 profile = "minimal"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- update `rust-toolchain.toml` from Rust `1.87.0` to `1.94.1`
- add `clippy` and `rustfmt` as required toolchain components
- set `rust-version = "1.94.1"` in `Cargo.toml`

## Testing

- [ ] Not run
- [x] `cargo test`
- [ ] Other

## Self-review checklist

- [ ] Threat or security risk changed
- [ ] Input validation changed
- [ ] Auth or permissions changed
- [x] Dependency or license changed
- [ ] Tests added or updated
- [x] I re-read the final diff before merge
